### PR TITLE
Use portable way of linking libdl

### DIFF
--- a/hardware/libhardware/CMakeLists.txt
+++ b/hardware/libhardware/CMakeLists.txt
@@ -2,5 +2,5 @@ add_library(hardware
     hardware.c
     )
 
-target_link_libraries(hardware cutils dl)
+target_link_libraries(hardware cutils ${CMAKE_DL_LIBS})
 


### PR DESCRIPTION
Not all systems need/have libdl, CMAKE_DL_LIBS handles this properly